### PR TITLE
Quote active xml characters

### DIFF
--- a/backupdives.py
+++ b/backupdives.py
@@ -13,6 +13,7 @@
 
 import sys, requests, json, time, jinja2, hashlib
 from datetime import datetime
+from xml.sax.saxutils import escape, quoteattr
 
 CHUNKSIZE = 20 # Don't load everything at once
 
@@ -224,7 +225,7 @@ class DeepbluLog(object):
 		self.diveDate = datetime.strptime(jsonLog.get('diveDTRaw'), "%Y,%m,%d,%H,%M,%S")
 		self.airPressure = jsonLog.get('airPressure', 1000)
 		self.waterType = jsonLog.get('waterType', 0)
-		self.notes = jsonLog.get('notes', '')
+		self.notes = quoteattr(escape(jsonLog.get('notes', '')))
 		self.diveDuration = jsonLog.get('diveDuration', '')
 		self.minTemp = DeepbluTools.convertTemp(jsonLog.get('diveMinTemperature', None))
 		self.maxDepth = DeepbluTools.getDepth(jsonLog.get('diveMaxDepth', None), self.airPressure, self.waterType)


### PR DESCRIPTION
otherwise logs containing characters <&<"' in the notes
lead to ill-formed xml.

Note: I am not a python programmer, this is not really tested.

Example: Try user Srodriguez32's log on Deepblu

Fixes #1

Signed-off-by: Robert C. Helling <helling@atdotde.de>