### PR TITLE
Pkg structure

### DIFF
--- a/setup.cfg
+++ b/setup.cfg
@@ -22,7 +22,7 @@ classifiers =
 
 [options]
 zip_safe = False
-packages = find:
+packages = find_namespace:
 include_package_data = True
 package_dir =
     =src

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,3 @@
+from setuptools import setup
+
+setup()


### PR DESCRIPTION
Small adjustment to make the models autodiscoverable, cfr. https://setuptools.pypa.io/en/latest/userguide/package_discovery.html#src-layout

- The main init file will still be required
- I kept the `__init__.py` inside the deepblu subfolder, as this one pushes the required classes to the module level and I do not see another way. 

Hence, all-together been able to ditch one init-dile :-)

__Note__ I also added a minimal `setup.py`, as this provides the option to `pip install -e .` install in editable mode, making things much easier to test when updating code. 